### PR TITLE
update: unint to int32 according VarInt documentation

### DIFF
--- a/status.go
+++ b/status.go
@@ -7,7 +7,7 @@ import (
 // Server info version
 type Version struct {
 	Name     string `json:"name"`     // Version name
-	Protocol uint   `json:"protocol"` // Version protocol number
+	Protocol int32  `json:"protocol"` // Version protocol number
 }
 
 // Server info player
@@ -18,8 +18,8 @@ type Player struct {
 
 // Server info players
 type Players struct {
-	Max    uint     `json:"max"`    // Max amount of players allowed
-	Online uint     `json:"online"` // Amount of players online
+	Max    int32     `json:"max"`    // Max amount of players allowed
+	Online int32     `json:"online"` // Amount of players online
 	Sample []Player // Sample of online players
 }
 


### PR DESCRIPTION
In some case, Minecraft server owner set maximum server players to negative (eg. -1), or protocol set to -1 to deny all incoming protocols.

In this case, pinger crash because uint is not compatible with negative number.

Fixing this issue by changing the type of protocol, max and online players to int32 (according to VarInt specification)