### PR TITLE
Added support for Bungeecord's proxy_protocol option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/Raqbit/mc-pinger
 
 go 1.12
+
+require github.com/pires/go-proxyproto v0.5.0 // indirect


### PR DESCRIPTION
I have a request https://github.com/itzg/docker-bungeecord/issues/51 from a user of my bungeecord Docker image (and indirectly https://github.com/itzg/mc-monitor/issues/6 ) to support Bungeecord's `proxy_protocol` option.

Since this new configuration of `Pinger` needed to be combined with context/timeout support I decided to introduce [a functional options pattern](https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis) to allow for backward/forward compatible options on the `New` function.

For example:
```go
	options := []mcpinger.McPingerOption{}
	if c.Timeout > 0 {
		options = append(options, mcpinger.WithTimeout(c.Timeout))
	}
	if c.UseProxy {
		options = append(options, mcpinger.WithProxyProto(c.ProxyVersion))
	}
	pinger := mcpinger.New(c.Host, uint16(c.Port), options...)
```