### PR TITLE
Fix timeout option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/Raqbit/mc-pinger
 
 go 1.12
 
-require github.com/pires/go-proxyproto v0.5.0 // indirect
+require github.com/pires/go-proxyproto v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/pires/go-proxyproto v0.5.0 h1:A4Jv4ZCaV3AFJeGh5mGwkz4iuWUYMlQ7IoO/GTuSuLo=
+github.com/pires/go-proxyproto v0.5.0/go.mod h1:Odh9VFOZJCf9G8cLW5o435Xf1J95Jw9Gw5rnCjcwzAY=

--- a/pinger.go
+++ b/pinger.go
@@ -51,6 +51,9 @@ func (p *mcPinger) Ping() (*ServerInfo, error) {
 		p.Context = ctx
 		defer cancel()
 	}
+	if p.Context == nil {
+		p.Context = context.Background()
+	}
 	return p.ping()
 }
 
@@ -176,9 +179,8 @@ func (p *mcPinger) writeProxyHeader(conn net.Conn) error {
 // to connect to a minecraft server
 func New(host string, port uint16, options ...McPingerOption) Pinger {
 	p := &mcPinger{
-		Host:    host,
-		Port:    port,
-		Context: context.Background(),
+		Host: host,
+		Port: port,
 	}
 	for _, opt := range options {
 		opt(p)


### PR DESCRIPTION
`New()` was defaulting to using a background context, which meant the timeout was not being applied as it does not want to override a configured context (`using WithContext` or `NewContext`).

Fixed by not setting the background context in the constructor, but when we are about to ping and no context is set yet.