### PR TITLE
Deprecate alternate Pinger constructors

### DIFF
--- a/_example/context-ping/main.go
+++ b/_example/context-ping/main.go
@@ -26,7 +26,8 @@ func main() {
 	}()
 
 	// Create new Pinger with 10 seconds Timeout
-	pinger := mcpinger.NewContext(ctx, "mc.herobone.de", 25565)
+	pinger := mcpinger.New("mc.herobone.de", 25565, mcpinger.WithContext(ctx))
+
 	// Get server info
 	info, err := pinger.Ping()
 

--- a/_example/timed-example/main.go
+++ b/_example/timed-example/main.go
@@ -10,7 +10,7 @@ import (
 
 func main() {
 	// Create new Pinger with 10 seconds Timeout
-	pinger := mcpinger.NewTimed("mc.herobone.de", 25565, 10*time.Second)
+	pinger := mcpinger.New("mc.herobone.de", 25565, mcpinger.WithTimeout(10*time.Second))
 
 	// Get server info
 	info, err := pinger.Ping()

--- a/pinger.go
+++ b/pinger.go
@@ -190,21 +190,17 @@ func New(host string, port uint16, options ...McPingerOption) Pinger {
 
 // NewTimed Creates a new Pinger with specified host & port
 // to connect to a minecraft server with Timeout
+//
+// Deprecated: Use the WithTimeout option & New instead
 func NewTimed(host string, port uint16, timeout time.Duration) Pinger {
-	return &mcPinger{
-		Host:    host,
-		Port:    port,
-		Timeout: timeout,
-	}
+	return New(host, port, WithTimeout(timeout))
 }
 
 // NewContext Creates a new Pinger with the given Context
+//
+// Deprecated: Use the WithContext option & New instead
 func NewContext(ctx context.Context, host string, port uint16) Pinger {
-	return &mcPinger{
-		Host:    host,
-		Port:    port,
-		Context: ctx,
-	}
+	return New(host, port, WithContext(ctx))
 }
 
 // McPingerOption instances can be combined when creating a new Pinger


### PR DESCRIPTION
With the new Options added by #8, the `NewContext` & `NewTimeout` constructor became redundant.

This PR deprecates the `NewContext` & `NewTimeout` APIs, updates examples and re-implements the deprecated functions using their respective options.