### PR TITLE
Added read deadline during ping to handle paused servers

### DIFF
--- a/pinger.go
+++ b/pinger.go
@@ -105,6 +105,11 @@ func (p *mcPinger) ping() (*ServerInfo, error) {
 		return nil, err
 	}
 
+	if p.Timeout > 0 {
+		// When a remote process is bound, but paused, the connect succeeds without context timeout;
+		// however, the response packet just never comes back.
+		_ = conn.SetReadDeadline(time.Now().Add(p.Timeout))
+	}
 	res, err := p.readPacket(rd)
 
 	if err != nil {


### PR DESCRIPTION
During this PR, https://github.com/itzg/docker-minecraft-server/pull/1059, a contributor and I discovered that when the Minecraft server process was paused, the timeout passed to the mc-pinger's context was not timing out the ping operation. 

Looking with the debugger at that point I discovered it's because it is blocked within the `readPacket` call. Apparently when a process is paused, its bound TCP port remains connectable, but being paused the ping response packet is never going to happen.