### PR TITLE
Fix string encoding size check

### DIFF
--- a/encoding/types.go
+++ b/encoding/types.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
-	"math"
 )
 
 const (
@@ -133,8 +132,8 @@ func ReadString(r io.Reader) (String, error) {
 	}
 
 	// Checking if string size is valid
-	if l < 0 || l > math.MaxInt16 {
-		return "", errors.New("string length out of bounds")
+	if l < 0 {
+		return "", errors.New("string cannot have a negative length")
 	}
 
 	// Creating string buffer with the specified size


### PR DESCRIPTION
The previously set limit of MaxInt16 was based on "Maximum n value is 32767" on wiki.vg/Protocol, but it appears this limit is not enforced in some cases.

For example, the JSON size of server query responses can grow past this limit, thus triggering the out-of-bounds error on large responses (e.g. modded forge servers sending mod lists for compat checks)

Fixes #15

----

Removed the max length check, as we now assume the max length of strings is the maximum size of a `VarInt`. Minimum check stays since the `VarInt` can but should not be negative.